### PR TITLE
fix: resolve command EOF callback and race condition in RunWithContext

### DIFF
--- a/helper/command/command.go
+++ b/helper/command/command.go
@@ -85,7 +85,6 @@ func (c *Command) Run(opt ...Option) (exitCode int, err error) {
 
 func (c *Command) RunWithContext(ctx context.Context, opt ...Option) (exitCode int, err error) {
 	wg := &sync.WaitGroup{}
-	defer wg.Wait()
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
 		cmd = exec.CommandContext(ctx, c.Command, c.Params...)
@@ -112,6 +111,9 @@ func (c *Command) RunWithContext(ctx context.Context, opt ...Option) (exitCode i
 	go c.readerStreamProcessor(ctx, wg, stderr, c.stderrFunc)
 
 	err = cmd.Wait()
+	// Wait for stream processor goroutines to finish before returning,
+	// so callers can safely read captured output immediately.
+	wg.Wait()
 	if err != nil {
 		var msg *exec.ExitError
 		if errors.As(err, &msg) {
@@ -156,14 +158,18 @@ loop:
 	for {
 		select {
 		case <-ctx.Done():
+			if callbackFunc != nil {
+				callbackFunc(nil, true)
+			}
 			return
 		default:
 			readed, err := reader.Read(buffer)
 			if err != nil {
-				if err == io.EOF {
-					if callbackFunc != nil {
-						callbackFunc(nil, true)
-					}
+				// Treat any read error as end-of-stream. cmd.Wait() closes
+				// the pipe, which may surface as io.ErrClosedPipe or
+				// os.ErrClosed rather than io.EOF.
+				if callbackFunc != nil {
+					callbackFunc(nil, true)
 				}
 				break loop
 			}

--- a/helper/command/command_test.go
+++ b/helper/command/command_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestNewCommand(t *testing.T) {
@@ -223,13 +222,13 @@ func TestCommandExecution(t *testing.T) {
 
 	var mu sync.Mutex
 	var output []byte
-	done := make(chan struct{})
+	eofCalled := false
 
 	stdoutFunc := func(buffer []byte, exit bool) {
 		mu.Lock()
 		defer mu.Unlock()
 		if exit {
-			close(done)
+			eofCalled = true
 			return
 		}
 		output = append(output, buffer...)
@@ -254,17 +253,16 @@ func TestCommandExecution(t *testing.T) {
 		t.Errorf("exitCode = %d, want 0", exitCode)
 	}
 
-	// RunWithContext uses defer wg.Wait() so stdout goroutines may still
-	// be running after it returns. Wait for the EOF callback.
-	select {
-	case <-done:
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timed out waiting for stdout EOF callback")
-	}
-
+	// RunWithContext now waits for goroutines before returning,
+	// so output and eofCalled are safe to read without extra waiting.
 	mu.Lock()
 	outputStr := strings.TrimSpace(string(output))
+	gotEOF := eofCalled
 	mu.Unlock()
+
+	if !gotEOF {
+		t.Error("EOF callback was never called")
+	}
 
 	if len(outputStr) == 0 {
 		t.Error("No output captured")


### PR DESCRIPTION
## Summary

- **`readerStreamProcessor`**: now calls the EOF callback on any read error (not just `io.EOF`). When `cmd.Wait()` closes stdout/stderr pipes, the goroutine receives `io.ErrClosedPipe` or `os.ErrClosed` instead of `io.EOF`, causing the callback to never fire — this was the root cause of `TestCommandExecution` timing out on CI.
- **`RunWithContext`**: moved `wg.Wait()` from a `defer` (which runs after return values are set) to an explicit call after `cmd.Wait()` and before returning. This eliminates the race condition where callers could read output before goroutines finished writing it.
- Simplified `TestCommandExecution` to verify the EOF callback directly instead of using a channel + timeout workaround.

Fixes the CI test failure introduced in #86.