### PR TITLE
fix: use registry cache mode=max for Docker build cache images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ buildcache-ffmpeg: ## Build and push FFmpeg cache image
 	docker buildx build \
 		--push \
 		--cache-from type=registry,ref=$(FFMPEG_CACHE_IMAGE) \
-		--cache-to type=inline \
+		--cache-to type=registry,ref=$(FFMPEG_CACHE_IMAGE),mode=max \
 		-t $(FFMPEG_CACHE_IMAGE) \
 		-f Dockerfile \
 		--target builder-ffmpeg \
@@ -136,7 +136,7 @@ buildcache-pgs: ## Build and push PGS cache image
 	docker buildx build \
 		--push \
 		--cache-from type=registry,ref=$(PGS_CACHE_IMAGE) \
-		--cache-to type=inline \
+		--cache-to type=registry,ref=$(PGS_CACHE_IMAGE),mode=max \
 		-t $(PGS_CACHE_IMAGE) \
 		-f Dockerfile \
 		--target builder-pgs \
@@ -149,7 +149,6 @@ buildcontainer-% publishcontainer-%:
 	@export DOCKER_BUILD_ARG="$(if $(findstring publishcontainer,$@),--push,--load) $(if $(filter false,$(CACHE)),--no-cache,)"; \
 	docker buildx build \
 		$${DOCKER_BUILD_ARG} \
-		--cache-to type=inline \
 		--cache-from type=registry,ref=$(IMAGE_NAME):$*-$(GIT_BRANCH_NAME) \
 		--cache-from type=registry,ref=$(IMAGE_NAME):$*-main \
 		--cache-from type=registry,ref=$(FFMPEG_CACHE_IMAGE) \


### PR DESCRIPTION
## Summary

- Switch `buildcache-ffmpeg` and `buildcache-pgs` from `--cache-to type=inline` to `--cache-to type=registry,ref=<image>,mode=max`. `type=inline` embeds cache metadata in the image manifest which is unreliable across different buildx builder instances. `type=registry` with `mode=max` stores all intermediate layers as a separate cache manifest, ensuring `builder-ffmpeg` and `builder-pgs` layers are properly reused.
- Remove `--cache-to type=inline` from `buildcontainer-*`/`publishcontainer-*` targets — these use `--load` on PRs (no push), so inline cache export has no effect.

### Context

The current in-progress main build (first after #88) will push cache images with `type=inline`, which may partially work since each `buildcache-*` target builds a single stage. This PR ensures subsequent `buildcache` runs use the more robust `type=registry,mode=max` approach, giving reliable cache hits for the ~50min FFmpeg and ~5min PGS stages.