### PR TITLE
test: verify Docker build cache works with pinned base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# Makefile for transcoderd — distributed video transcoding system
 GO ?= go
 GOFMT ?= $(GO)fmt
 FIRST_GOPATH := $(firstword $(subst :, ,$(shell $(GO) env GOPATH)))


### PR DESCRIPTION
## Summary
- Trivial change (added a comment to Makefile) to trigger CI and verify that Docker build cache works after pinning base images in PR #90.
- If the Build step completes in < 5min instead of ~60min, the cache is working.
- This PR can be closed without merging after verification.