### PR TITLE
fix: use pre-built Docker builder images instead of BuildKit cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,16 +2,11 @@ name: Build and Push
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
-    inputs:
-      cache:
-        description: "Use cache"
-        required: false
-        default: true
+
 permissions:
   contents: write
   pull-requests: write
@@ -21,27 +16,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Determine Cache Behavior
-        id: cache
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "cache=${{ inputs.cache }}" >> "$GITHUB_OUTPUT"
-            echo "CACHE=${{ inputs.cache }}" >> "$GITHUB_ENV"
-          else
-            echo "cache=true" >> "$GITHUB_OUTPUT"
-            echo "CACHE=true" >> "$GITHUB_ENV"
-          fi
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: jetify-com/devbox-install-action@v0.12.0
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Install devbox
-        uses: jetify-com/devbox-install-action@v0.12.0
-        with:
-          enable-cache: ${{ steps.cache.outputs.cache }}
-
-      - name: Set up release please
+      - name: Release please
         if: github.event_name != 'pull_request'
         id: release
         uses: googleapis/release-please-action@v4
@@ -49,36 +28,51 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - name: Set Release PROJECT_VERSION
-        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Set release version
+        if: steps.release.outputs.release_created
         run: echo "PROJECT_VERSION=v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }}" >> $GITHUB_ENV
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Run Tests
+      - name: Test
         run: devbox run -- make test
+
+      # Ensure pre-built builder images exist in the registry. These are normally
+      # published via the "Publish builder images" workflow and only need rebuilding
+      # when FFmpeg/PGS dependencies change. This step is a safety net that builds
+      # and pushes them if they are missing (e.g. first run after setup).
+      - name: Ensure builder images exist
+        run: |
+          for target in builder-ffmpeg builder-pgs; do
+            if ! docker manifest inspect ghcr.io/segator/transcoderd:${target} > /dev/null 2>&1; then
+              echo "Image ${target} not found, building and pushing..."
+              make publish-${target}
+            else
+              echo "Image ${target} already exists, skipping."
+            fi
+          done
+
       - name: Build
         run: devbox run -- make build
 
-      # Push updated cache images so future builds (PRs and main) reuse FFmpeg/PGS layers.
-      - name: Update cache images (FFmpeg, PGS)
-        if: github.event_name != 'pull_request'
-        run: make buildcache
-      - name: Publish Docker containers
+      - name: Publish
         if: github.event_name != 'pull_request'
         run: make publish
-      - name: Publish simplified tag artifacts
-        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Publish release tags
+        if: steps.release.outputs.release_created
         run: |
           PROJECT_VERSION=v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} make publish
           PROJECT_VERSION=v${{ steps.release.outputs.major }} make publish
-      - name: Upload Github release assets
-        if: ${{ steps.release.outputs.release_created }}
+
+      - name: Upload release assets
+        if: steps.release.outputs.release_created
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} ./dist/*  --clobber
+        run: gh release upload ${{ steps.release.outputs.tag_name }} ./dist/* --clobber

--- a/.github/workflows/publish-builders.yml
+++ b/.github/workflows/publish-builders.yml
@@ -1,0 +1,46 @@
+# Publish the slow-to-build Docker builder images (FFmpeg, PGS) to the registry.
+# These images are consumed by the main Dockerfile via FROM args, so CI builds
+# never have to rebuild FFmpeg (~50min) or PGS (~5min) from source.
+#
+# Run this workflow manually when:
+#   - FFmpeg build script version changes
+#   - PGS/tessdata dependencies change
+#   - Ubuntu or .NET SDK base image needs updating
+name: Publish builder images
+
+on:
+  workflow_dispatch:
+    inputs:
+      builder:
+        description: "Which builder to publish"
+        required: true
+        type: choice
+        options:
+          - all
+          - ffmpeg
+          - pgs
+
+permissions:
+  packages: write
+
+jobs:
+  publish-builders:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish FFmpeg builder
+        if: inputs.builder == 'all' || inputs.builder == 'ffmpeg'
+        run: make publish-builder-ffmpeg
+
+      - name: Publish PGS builder
+        if: inputs.builder == 'all' || inputs.builder == 'pgs'
+        run: make publish-builder-pgs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,95 +1,101 @@
-# Pin to a dated tag so BuildKit cache keys are deterministic across CI runs.
-# The rolling "ubuntu:24.04" tag resolves to different digests over time, which
-# invalidates the entire builder-ffmpeg cache chain on ephemeral CI builders.
-# To update: pick a newer tag from https://hub.docker.com/_/ubuntu/tags?name=noble-
-ARG BASE_IMAGE=ubuntu:noble-20251013
-FROM ${BASE_IMAGE} AS builder-ffmpeg
+# Pre-built builder images — pulled from the registry instead of rebuilding.
+# Override with --build-arg to rebuild from scratch (or use --target builder-ffmpeg).
+# To publish new builder images: make publish-builder-ffmpeg / make publish-builder-pgs
+ARG FFMPEG_IMAGE=ghcr.io/segator/transcoderd:builder-ffmpeg
+ARG PGS_IMAGE=ghcr.io/segator/transcoderd:builder-pgs
+
+# =============================================================================
+# Stage: builder-ffmpeg
+# Compiles FFmpeg from source (~50min). Published as a standalone image so CI
+# never has to rebuild it. To rebuild: make publish-builder-ffmpeg
+# =============================================================================
+FROM ubuntu:noble-20251013 AS builder-ffmpeg
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get -y --no-install-recommends install git build-essential curl ca-certificates libva-dev \
-        python3 python-is-python3 ninja-build meson git curl \
-    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
+        python3 python-is-python3 ninja-build meson \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
     && update-ca-certificates
 
 WORKDIR /app
 
 ARG FFMPEG_BUILD_SCRIPT_VERSION=v1.59
-# ADD doesn't cache when used from URL
-RUN git clone --depth 1 --branch ${FFMPEG_BUILD_SCRIPT_VERSION}  https://github.com/markus-perl/ffmpeg-build-script.git && \
+RUN git clone --depth 1 --branch ${FFMPEG_BUILD_SCRIPT_VERSION} https://github.com/markus-perl/ffmpeg-build-script.git && \
     cd ffmpeg-build-script && \
     SKIPINSTALL=yes ./build-ffmpeg --build --enable-gpl-and-non-free && \
     rm -rf packages
 
-FROM debian:trixie-20241223-slim  AS base
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        mkvtoolnix \
-        libva-drm2 \
-        wget \
-    && rm -rf /var/lib/apt/lists/*
-
-COPY --from=builder-ffmpeg /app/ffmpeg-build-script/workspace/bin/ff* /usr/bin/
-
-# Check shared library
-RUN ldd /usr/bin/ffmpeg && \
-    ldd /usr/bin/ffprobe && \
-    ldd /usr/bin/ffplay
-
-FROM base AS server
-COPY ./dist/transcoderd-server /app/transcoderd-server
-ENTRYPOINT ["/app/transcoderd-server"]
-
-# Pin to a specific patch version for deterministic cache keys (same reason as BASE_IMAGE).
+# =============================================================================
+# Stage: builder-pgs
+# Builds PgsToSrt .NET tool + downloads tessdata (~5min). Also published as a
+# standalone image. To rebuild: make publish-builder-pgs
+# =============================================================================
 FROM mcr.microsoft.com/dotnet/sdk:8.0.419 AS builder-pgs
+
 WORKDIR /src
 ARG tessdata_version=ced78752cc61322fb554c280d13360b35b8684e4
 ARG pgstosrt_version=ef11919491b5c98f9dcdaf13d721596e60efb7ed
 
 RUN apt-get -y update && \
-  apt-get -y upgrade && \
-  apt-get -y install \
-    automake \
-    ca-certificates \
-    g++ \
-    libtool \
-    libtesseract-dev \
-    make \
-    pkg-config \
-    wget \
-    unzip \
-    libc6-dev
+    apt-get -y upgrade && \
+    apt-get -y install \
+        automake ca-certificates g++ libtool libtesseract-dev \
+        make pkg-config wget unzip libc6-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN wget -O tessdata.zip "https://github.com/tesseract-ocr/tessdata/archive/${tessdata_version}.zip" && \
-    unzip tessdata.zip && \
-    rm tessdata.zip && \
+    unzip tessdata.zip && rm tessdata.zip && \
     mv tessdata-${tessdata_version} tessdata
 
 RUN wget -O pgstosrt.zip "https://github.com/Tentacule/PgsToSrt/archive/${pgstosrt_version}.zip" && \
-    unzip pgstosrt.zip && \
-    rm pgstosrt.zip && \
+    unzip pgstosrt.zip && rm pgstosrt.zip && \
     cd PgsToSrt-${pgstosrt_version}/src && \
-    dotnet restore  && \
+    dotnet restore && \
     dotnet publish -c Release -f net8.0 -o /src/PgsToSrt/out
+
+# =============================================================================
+# Stage: base
+# Runtime base with FFmpeg binaries from the pre-built image.
+# =============================================================================
+FROM ${FFMPEG_IMAGE} AS ffmpeg-bins
+
+FROM debian:trixie-20241223-slim AS base
+RUN apt-get update \
+    && apt-get install -y ca-certificates mkvtoolnix libva-drm2 wget \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ffmpeg-bins /app/ffmpeg-build-script/workspace/bin/ff* /usr/bin/
+
+RUN ldd /usr/bin/ffmpeg && \
+    ldd /usr/bin/ffprobe && \
+    ldd /usr/bin/ffplay
+
+# =============================================================================
+# Stage: server
+# =============================================================================
+FROM base AS server
+COPY ./dist/transcoderd-server /app/transcoderd-server
+ENTRYPOINT ["/app/transcoderd-server"]
+
+# =============================================================================
+# Stage: worker
+# =============================================================================
+FROM ${PGS_IMAGE} AS pgs-bins
 
 FROM base AS worker
 WORKDIR /app
-COPY --from=builder-pgs /src/tessdata /app/tessdata
-COPY --from=builder-pgs /src/PgsToSrt/out /app
+COPY --from=pgs-bins /src/tessdata /app/tessdata
+COPY --from=pgs-bins /src/PgsToSrt/out /app
 RUN apt-get update && \
     apt-get install -y libtesseract-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN wget https://dot.net/v1/dotnet-install.sh -O dotnet-install.sh && \
     chmod +x dotnet-install.sh && \
     ./dotnet-install.sh --channel 8.0 --runtime dotnet --install-dir /usr/share/dotnet && \
     ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet && \
     rm dotnet-install.sh
 
-
 COPY ./dist/transcoderd-worker /app/transcoderd-worker
-
 ENTRYPOINT ["/app/transcoderd-worker"]
-

--- a/Makefile
+++ b/Makefile
@@ -9,28 +9,42 @@ GIT_BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9.
 BUILD_DATE := $(shell date +%Y-%m-%dT%H:%M:%SZ)
 IMAGE_NAME ?= ghcr.io/segator/transcoderd
 PROJECT_VERSION ?= $(shell cat version.txt)-dev
-CACHE ?=true
+CACHE ?= true
 
 
 .DEFAULT: help
 .PHONY: help
-help:	## show this help menu.
+help: ## show this help menu.
 	@echo "Usage: make [TARGET ...]"
 	@echo ""
 	@@egrep -h "#[#]" $(MAKEFILE_LIST) | sed -e 's/\\$$//' | awk 'BEGIN {FS = "[:=].*?#[#] "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 	@echo ""
 
+# ---------------------------------------------------------------------------
+# Code quality
+# ---------------------------------------------------------------------------
 .PHONY: fmt
-fmt: ## Code Format
-	go fmt  ./...
+fmt: ## Format Go code
+	go fmt ./...
 
+.PHONY: lint
+lint: ## Run linters
+	@golangci-lint run
+
+.PHONY: lint-fix
+lint-fix: ## Run linters with auto-fix
+	@golangci-lint run --fix
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
 .PHONY: test
-test: ## Run unit tests
+test: ## Run unit tests with coverage
 	@mkdir -p build
 	$(GO) test -v -coverprofile=build/coverage.out -covermode=atomic ./...
 
 .PHONY: test-race
-test-race: ## Run unit tests with race detector (requires more memory)
+test-race: ## Run unit tests with race detector
 	@mkdir -p build
 	$(GO) test -v -race -coverprofile=build/coverage.out -covermode=atomic ./...
 
@@ -40,120 +54,73 @@ test-short: ## Run unit tests in short mode
 	$(GO) test -v -short ./...
 
 .PHONY: test-integration
-test-integration: ## Run integration tests
-	@echo "Running integration tests..."
+test-integration: ## Run integration tests (requires Docker)
 	$(GO) test -tags=integration -v -timeout 5m ./integration/...
 
 .PHONY: test-all
 test-all: test test-integration ## Run all tests (unit + integration)
 
 .PHONY: test-coverage
-test-coverage: test ## Run tests and show coverage
+test-coverage: test ## Run tests and open coverage in browser
 	$(GO) tool cover -html=build/coverage.out
 
-.PHONY: test-summary
-test-summary: ## Show test coverage summary
-	@echo "Running tests and generating coverage report..."
-	@mkdir -p build
-	@$(GO) test ./... -short -coverprofile=build/coverage.out -covermode=atomic > /dev/null 2>&1
-	@echo "\n📊 Coverage Summary:"
-	@$(GO) tool cover -func=build/coverage.out | grep total | awk '{print "Total Coverage: " $$3}'
-	@echo "\n📦 Package Coverage:"
-	@$(GO) test ./... -short -coverprofile=build/coverage.out -covermode=atomic 2>&1 | grep "coverage:" | sort -t: -k2 -rn
-
-.PHONY: lint
-lint: ## Linters
-	@golangci-lint run
-
-.PHONY: lint-fix
-lint-fix: ## Lint fix if possible
-	@golangci-lint run --fix
-
-.PHONY: act-ci
-act-ci: ## Run CI workflow locally with act
-	@echo "Running CI workflow with act..."
-	act -j ci
-
-.PHONY: act-ci-dryrun
-act-ci-dryrun: ## Dry run of CI workflow with act
-	@echo "Dry run of CI workflow..."
-	act -j ci -n
-
-.PHONY: act-lint
-act-lint: ## Run lint workflow locally with act
-	@echo "Running lint workflow with act..."
-	act -W .github/workflows/lint.yml
-
-.PHONY: act-list
-act-list: ## List all workflows and jobs
-	@echo "Available workflows and jobs:"
-	@act -l
-
-.PHONY: act-test
-act-test: ## Run only the test step with act
-	@echo "Running tests with act..."
-	act -j ci --workflows .github/workflows/main.yml -s GITHUB_TOKEN=dummy
-
-
+# ---------------------------------------------------------------------------
+# Go build
+# ---------------------------------------------------------------------------
 .PHONY: build
-build: buildgo-server buildgo-worker buildcontainer-server buildcontainer-worker  ## Build all artifacts (Go binaries + Docker containers)
+build: buildgo-server buildgo-worker buildcontainer-server buildcontainer-worker ## Build everything (Go + Docker)
 
 .PHONY: buildgo
-buildgo: buildgo-server buildgo-worker  ## Build Go binaries only (no Docker)
-
-
+buildgo: buildgo-server buildgo-worker ## Build Go binaries only
 
 .PHONY: buildgo-%
 buildgo-%:
 	@echo "Building dist/transcoderd-$*"
-	@CGO_ENABLED=0 go build  -ldflags "-X main.ApplicationName=transcoderd-$* -X transcoder/version.Version=${PROJECT_VERSION} -X transcoder/version.Commit=${GIT_COMMIT_SHA} -X transcoder/version.Date=${BUILD_DATE}" -o dist/transcoderd-$* $*/main.go
+	@CGO_ENABLED=0 go build \
+		-ldflags "-X main.ApplicationName=transcoderd-$* -X transcoder/version.Version=${PROJECT_VERSION} -X transcoder/version.Commit=${GIT_COMMIT_SHA} -X transcoder/version.Date=${BUILD_DATE}" \
+		-o dist/transcoderd-$* $*/main.go
 
-.PHONY: publish
-publish: publishcontainer-server publishcontainer-worker ## Publish all artifacts
+# ---------------------------------------------------------------------------
+# Docker — pre-built builder images (FFmpeg ~50min, PGS ~5min)
+#
+# These are published once and reused by all CI builds via FROM in Dockerfile.
+# Rebuild only when FFmpeg version or PGS dependencies change:
+#   make publish-builder-ffmpeg
+#   make publish-builder-pgs
+# ---------------------------------------------------------------------------
+.PHONY: publish-builder-ffmpeg
+publish-builder-ffmpeg: ## Build & push FFmpeg builder image (~50min)
+	docker buildx build --push \
+		-t $(IMAGE_NAME):builder-ffmpeg \
+		-f Dockerfile --target builder-ffmpeg .
 
+.PHONY: publish-builder-pgs
+publish-builder-pgs: ## Build & push PGS builder image (~5min)
+	docker buildx build --push \
+		-t $(IMAGE_NAME):builder-pgs \
+		-f Dockerfile --target builder-pgs .
 
-# Dedicated cache refs for slow build stages (FFmpeg ~50min, PGS ~5min).
-# Using separate refs avoids manifest-type collisions between image push
-# and cache export that cause cross-run cache misses.
-FFMPEG_CACHE_REF := $(IMAGE_NAME):buildcache-ffmpeg
-PGS_CACHE_REF := $(IMAGE_NAME):buildcache-pgs
-
-.PHONY: buildcache
-buildcache: buildcache-ffmpeg buildcache-pgs ## Export cache for slow build stages to registry
-
-.PHONY: buildcache-ffmpeg
-buildcache-ffmpeg: ## Build and export FFmpeg cache to registry
-	docker buildx build \
-		--cache-from type=registry,ref=$(FFMPEG_CACHE_REF) \
-		--cache-to type=registry,ref=$(FFMPEG_CACHE_REF),mode=max \
-		-f Dockerfile \
-		--target builder-ffmpeg \
-		--output type=cacheonly \
-		. ;
-
-.PHONY: buildcache-pgs
-buildcache-pgs: ## Build and export PGS cache to registry
-	docker buildx build \
-		--cache-from type=registry,ref=$(PGS_CACHE_REF) \
-		--cache-to type=registry,ref=$(PGS_CACHE_REF),mode=max \
-		-f Dockerfile \
-		--target builder-pgs \
-		--output type=cacheonly \
-		. ;
-
-
+# ---------------------------------------------------------------------------
+# Docker — application images (server, worker)
+#
+# These pull the pre-built FFmpeg/PGS images automatically via FROM args
+# in the Dockerfile — no BuildKit cache needed.
+# ---------------------------------------------------------------------------
 .PHONY: buildcontainer-%
-.PHONY: publishcontainer-%
-buildcontainer-% publishcontainer-%:
-	@export DOCKER_BUILD_ARG="$(if $(findstring publishcontainer,$@),--push,--load) $(if $(filter false,$(CACHE)),--no-cache,)"; \
-	docker buildx build \
-		$${DOCKER_BUILD_ARG} \
-		--cache-from type=registry,ref=$(IMAGE_NAME):$*-$(GIT_BRANCH_NAME) \
-		--cache-from type=registry,ref=$(IMAGE_NAME):$*-main \
-		--cache-from type=registry,ref=$(FFMPEG_CACHE_REF) \
-		--cache-from type=registry,ref=$(PGS_CACHE_REF) \
+buildcontainer-%:
+	docker buildx build --load \
+		$(if $(filter false,$(CACHE)),--no-cache,) \
 		-t $(IMAGE_NAME):$*-$(PROJECT_VERSION) \
 		-t $(IMAGE_NAME):$*-$(GIT_BRANCH_NAME) \
-		-f Dockerfile \
-		--target $* \
-		. ;
+		-f Dockerfile --target $* .
+
+.PHONY: publishcontainer-%
+publishcontainer-%:
+	docker buildx build --push \
+		$(if $(filter false,$(CACHE)),--no-cache,) \
+		-t $(IMAGE_NAME):$*-$(PROJECT_VERSION) \
+		-t $(IMAGE_NAME):$*-$(GIT_BRANCH_NAME) \
+		-f Dockerfile --target $* .
+
+.PHONY: publish
+publish: publishcontainer-server publishcontainer-worker ## Publish server & worker images


### PR DESCRIPTION
## Summary

- Replace unreliable BuildKit `type=registry` cache with **pre-built builder images** (`builder-ffmpeg`, `builder-pgs`) published to GHCR as normal Docker images
- CI builds now `FROM` these pre-built images instead of rebuilding FFmpeg (~50min) from source — reducing typical build time to ~2-3min
- Add `publish-builders.yml` manual dispatch workflow for rebuilding builder images when dependencies change

## What changed

### Dockerfile
- Add `ARG FFMPEG_IMAGE` / `ARG PGS_IMAGE` at top, defaulting to `ghcr.io/segator/transcoderd:builder-{ffmpeg,pgs}`
- `base` stage copies FFmpeg bins from `ffmpeg-bins` (the pre-built image) instead of `builder-ffmpeg` (local build)
- `worker` stage copies PGS/tessdata from `pgs-bins` (the pre-built image) instead of `builder-pgs` (local build)
- Builder stages (`builder-ffmpeg`, `builder-pgs`) are kept in the Dockerfile for rebuilding via `--target`

### Makefile
- Removed all BuildKit cache machinery (`FFMPEG_CACHE_REF`, `PGS_CACHE_REF`, `buildcache-*` targets, `--cache-from`/`--cache-to` flags)
- Added `publish-builder-ffmpeg` and `publish-builder-pgs` targets
- Simplified `buildcontainer-%` and `publishcontainer-%` rules (no more cache refs)
- Removed `act-*` and `test-summary` targets
- Reorganized into clean sections with headers

### `.github/workflows/main.yml`
- Removed `workflow_dispatch` cache toggle input
- Removed `Determine Cache Behavior` step
- Added "Ensure builder images exist" safety-net step: checks `docker manifest inspect` and only builds+pushes if missing
- Removed `buildcache` step (no longer needed)
- Simplified step names and conditions

### `.github/workflows/publish-builders.yml` (NEW)
- Manual dispatch workflow to rebuild and push builder images
- Choice input: `all`, `ffmpeg`, or `pgs`

## First run behavior

The builder images (`ghcr.io/segator/transcoderd:builder-ffmpeg` and `builder-pgs`) **do not exist yet** in the registry. The first CI run will:
1. Detect they're missing via `docker manifest inspect`
2. Build and push them (~55min for FFmpeg, ~5min for PGS)
3. Then proceed with the normal fast build

All subsequent runs will just `docker pull` the pre-built images (~30s).