### PR TITLE
fix: remove progress tracker on completion

### DIFF
--- a/worker/console/console.go
+++ b/worker/console/console.go
@@ -117,9 +117,10 @@ func newProgressTracker(id string, notificationType model.NotificationType) (*pr
 		color = text.FgBlue
 	}
 	progressTracker := &progress.Tracker{
-		Message: color.Sprintf("[%s] %s", id, notificationType),
-		Total:   0,
-		Units:   unit,
+		Message:            color.Sprintf("[%s] %s", id, notificationType),
+		Total:              0,
+		Units:              unit,
+		RemoveOnCompletion: true,
 	}
 	return progressTracker, &color
 }


### PR DESCRIPTION
## Summary
- Add `RemoveOnCompletion: true` to progress trackers so they are cleaned up automatically when done