### PR TITLE
fix: treat PGS OCR with 0 items as warning instead of job failure

### DIFF
--- a/worker/step/PGStoSrtStep.go
+++ b/worker/step/PGStoSrtStep.go
@@ -103,7 +103,8 @@ func (p *PGSToSrtStepExecutor) convertPGSToSrt(ctx context.Context, tracker Trac
 	}
 
 	if strings.Contains(outLog, "with 0 items.") {
-		return fmt.Errorf("no items converted: %s", pgslog)
+		tracker.Logger().Warnf("PGS OCR produced 0 items for track %d (language=%s), continuing with empty subtitle", subtitle.Id, subtitle.Language)
+		return nil
 	}
 
 	subtitles, err := astisub.OpenFile(outputFilePath)


### PR DESCRIPTION
## Summary
- When PgsToSrt fails to OCR any subtitle items (corrupted PGS palette data → `IndexOutOfRangeException` in `SupDecoder.DecodeImage`), log a warning and continue instead of failing the entire job
- The empty .srt file already exists from PgsToSrt, so FFmpeg produces an empty subtitle track — better than no encode at all

## Impact
**38 failed jobs** in the last 7 days (Planeta Tierra S01, Borgen S03, etc.)

## Root Cause
Certain Blu-Ray PGS subtitle streams have palette data that PgsToSrt's `SupDecoder` can't decode. Every item throws `IndexOutOfRangeException`, resulting in 0 converted items. Previously this failed the entire job.