### PR TITLE
fix: add Dutch (dut/nl → nld) to PGS Tesseract language mapping

### DIFF
--- a/worker/step/PGStoSrtStep.go
+++ b/worker/step/PGStoSrtStep.go
@@ -150,6 +150,7 @@ func init() {
 	langMapping = append(langMapping, PGSTesseractLanguage{"isl", []string{"ice"}})
 	langMapping = append(langMapping, PGSTesseractLanguage{"ces", []string{"cze"}})
 	langMapping = append(langMapping, PGSTesseractLanguage{"ron", []string{"rum"}})
+	langMapping = append(langMapping, PGSTesseractLanguage{"nld", []string{"dut", "nl"}})
 }
 
 func calculateTesseractLanguage(language string) string {


### PR DESCRIPTION
## Summary
- Add mapping from ISO 639-2/B `dut` and ISO 639-1 `nl` to Tesseract `nld` for Dutch subtitle OCR

## Impact
**8 failed jobs** in the last 7 days — all Dutch PGS subtitles

## Root Cause
MKV files use `dut` (ISO 639-2/B) for Dutch, but Tesseract expects `nld` (ISO 639-2/T). Without the mapping, the raw `dut` was passed to Tesseract which doesn't recognize it.