### PR TITLE
fix: fallback to English when PGS subtitle has empty language tag

### DIFF
--- a/worker/step/PGStoSrtStep.go
+++ b/worker/step/PGStoSrtStep.go
@@ -153,6 +153,9 @@ func init() {
 }
 
 func calculateTesseractLanguage(language string) string {
+	if language == "" {
+		return "eng"
+	}
 	for _, mapping := range langMapping {
 		for _, mapLang := range mapping.mappingLanguage {
 			if language == mapLang {


### PR DESCRIPTION
## Summary
- Default to `eng` when a PGS subtitle stream has an empty language tag, instead of passing empty string to Tesseract

## Impact
**3 failed jobs** in the last 7 days

## Root Cause
Some MKV files have subtitle streams with no language metadata. The empty string gets passed directly to Tesseract which doesn't recognize it.