### PR TITLE
fix: skip empty PGS subtitle tracks instead of failing

### DIFF
--- a/worker/step/PGStoSrtStep_test.go
+++ b/worker/step/PGStoSrtStep_test.go
@@ -1,0 +1,56 @@
+package step
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteEmptySRT(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.srt")
+
+	err := writeEmptySRT(path)
+	if err != nil {
+		t.Fatalf("writeEmptySRT() error = %v", err)
+	}
+
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("os.Stat() error = %v", err)
+	}
+	if fi.Size() == 0 {
+		t.Errorf("writeEmptySRT() file size = 0, want non-empty valid SRT content")
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("os.ReadFile() error = %v", err)
+	}
+	want := "1\n00:00:00,000 --> 00:00:00,001\n \n\n"
+	if string(content) != want {
+		t.Errorf("writeEmptySRT() content = %q, want %q", string(content), want)
+	}
+}
+
+func TestMinPGSFileSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		fileSize int
+		wantSkip bool
+	}{
+		{"empty file", 0, true},
+		{"140 bytes header only", 140, true},
+		{"below threshold", 1023, true},
+		{"at threshold", 1024, false},
+		{"above threshold", 2048, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := int64(tt.fileSize) < minPGSFileSize
+			if got != tt.wantSkip {
+				t.Errorf("size %d < minPGSFileSize = %v, want %v", tt.fileSize, got, tt.wantSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Skip empty `.sup` files (< 1KB, e.g. 140-byte header-only tracks) before launching PgsToSrt, writing an empty SRT placeholder so ffmpeg input indexing stays correct
- Treat PgsToSrt "Starting OCR for 0 items" → "Saved with 0 items" as a skip (empty PGS) rather than a job failure
- Preserve the existing "0 items" failure for cases where PgsToSrt finds real data (N > 0) but all items fail OCR (corrupted PGS / tool bug)

## Context

Verified on `jvdivx.nodo.ovh` with real files:
- **Chicago Fire S09E13 track 6**: 140-byte `.sup` → PgsToSrt finds 0 items → was failing the job. Now skipped.
- **Chicago Fire S09E13 track 4**: 15MB `.sup` → PgsToSrt OCR'd 732 items successfully (unaffected by this change)
- **Planeta Tierra S01E01 track 6**: 12MB `.sup` → PgsToSrt finds 338 items, all crash with `IndexOutOfRangeException` → still correctly fails (upstream PgsToSrt bug)

Docker image verified: Tesseract 5.5.0, leptonica 1.84.1, dotnet 8.0.26, PgsToSrt v1.4.8 — all matching config defaults.

## Changed files

- `worker/step/PGStoSrtStep.go` — file size pre-check + "0 items found" skip logic
- `worker/step/PGStoSrtStep_test.go` — tests for `writeEmptySRT` and `minPGSFileSize` threshold